### PR TITLE
fix(ie11): remove ES6 arrow functions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,11 @@
       {
         "modules": false,
         "targets": {
-          "browsers": "> 1%",
+          "browsers": [
+            "last 2 versions",
+            "> 1%",
+            "ie > 10"
+          ],
           "uglify": true
         },
         "useBuiltIns": true

--- a/app/assets/javascripts/crud_datatables.js
+++ b/app/assets/javascripts/crud_datatables.js
@@ -1,4 +1,4 @@
-initializeCrudTable = (url,tableId, buttonsIdOrClass) => {
+function initializeCrudTable(url,tableId, buttonsIdOrClass) {
   var crudTable = $(tableId).DataTable({
     'buttons': ['copy', 'excel', 'pdf'],
     'processing': true,

--- a/app/assets/javascripts/topnav.js.erb
+++ b/app/assets/javascripts/topnav.js.erb
@@ -1,18 +1,10 @@
-$().ready(() => {
+$().ready(function (){
 
-	/*  Navigation */
-	$('.top-content .text').waypoint(() => {
-		$('nav').toggleClass('navbar-no-bg');
-	});
+    renderBackground("<%= asset_path('background.jpg') %>")
 
-    /* Background slideshow */
-    $('.top-content').backstretch("<%= asset_path('background.jpg') %>");
-
-    $('#top-navbar-1').on('shown.bs.collapse', () => {
-    	$('.top-content').backstretch("resize");
-    });
-    $('#top-navbar-1').on('hidden.bs.collapse', () => {
-    	$('.top-content').backstretch("resize");
+    /*  Navigation */
+    $('.top-content .text').waypoint(function(){
+        $('nav').toggleClass('navbar-no-bg');
     });
 
     /* Dropdowns */
@@ -22,7 +14,15 @@ $().ready(() => {
     new WOW().init();
 
     /* Placeholders */
-    $('input[type="text"], input[type="password"], textarea').each(() => {
+    $('input[type="text"], input[type="password"], textarea').each(function(){
         $(this).val( $(this).attr('placeholder') );
     });
 });
+
+function renderBackground(imgUrl){
+    /* Background slideshow */
+    $('.top-content').backstretch(imgUrl);
+    $('#top-navbar-1').on('shown.bs.collapse hidden.bs.collapse', function(){
+    	$('.top-content').backstretch("resize");
+    });
+}

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -2,5 +2,6 @@ const { environment } = require('@rails/webpacker')
 const customConfig = require('./custom')
 
 environment.config.merge(customConfig)
+environment.plugins.get("UglifyJs").options.uglifyOptions.ecma = 5
 
 module.exports = environment


### PR DESCRIPTION
This PR is partially reverting https://github.com/mberlanda/cheidelacoriera/commit/4d6e7b589ccc6fe03e0d3de7d28dfc27c3a35a4f since arrow functions are not supported in Internet Explorer 11.

Instead of delegate to a pre-compiler (babel or ts) the translation of syntax, I prefered to remove it since the usage was quite limited.

It should fix **#5 Restore IE11 Support**.