### PR TITLE
Handle multiple stops

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+.git/
+coverage/
 log/
 node_modules/
 tmp/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ AllCops:
     - '**/helpers/utility_helper*.rb'
     - app/controllers/dry_crud/*.rb
     - app/controllers/crud_controller.rb
+    - db/schema.rb
     - node_modules/**/*
     - spec/support/crud_*.rb
     - spec/controllers/crud_test_models_controller_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,6 +75,9 @@ Metrics/MethodLength:
     - app/controllers/reservations_controller.rb
     - app/decorators/*.rb
 
+Metrics/ModuleLength:
+  Exclude:
+    - app/schemas/reservation_schema.rb
 Rails:
   Enabled: true
 

--- a/app/controllers/crud/events_controller.rb
+++ b/app/controllers/crud/events_controller.rb
@@ -7,7 +7,8 @@ class Crud::EventsController < CrudController
   self.permitted_attrs = %i[date time season score notes venue home_team_id
                             bookable_from bookable_until requested_seats poster_url
                             confirmed_seats away_team_id competition_id total_seats
-                            rejected_seats pax audience transport_mean available_seats]
+                            rejected_seats pax audience transport_mean available_seats
+                            stops]
   self.search_columns = %i[date season home_team_id away_team_id competition_id
                            venue poster_url]
 
@@ -23,7 +24,7 @@ class Crud::EventsController < CrudController
 
   def datatable_columns
     %i[date season audience pax bookable_from bookable_until home_team_id away_team_id
-       transport_mean total_seats available_seats competition_id venue poster_url]
+       transport_mean total_seats available_seats competition_id venue poster_url stops]
   end
 
   def datatable_reservations

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -57,7 +57,7 @@ class EventsController < PublicController
     @models_label = I18n.t('activerecord.models.reservation.other')
     @model_name = 'reservation'
     @datatable_columns = %i[
-      status total_seats user_id fan_names phone_number notes
+      status total_seats user_id fan_names phone_number notes stop
     ]
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,7 +26,11 @@ class EventsController < PublicController
       # if @react_form
       default_fans_count = 1
       @reservation_form = {
-        schema: ReservationSchema.jsonschema(maximum: @event.pax, default: default_fans_count),
+        schema: ReservationSchema.jsonschema(
+          maximum: @event.pax,
+          default: default_fans_count,
+          stops: @event.available_stops
+        ),
         ui_schema: ReservationSchema.ui_schema,
         form_data: {
           event_id: @event.id,

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -10,12 +10,12 @@ class ReservationsController < CrudController
   layout false, only: %i[user_form status]
   respond_to :html, :js
 
-  self.permitted_attrs = [:phone_number, :notes, :status, :event_id, :total_seats, :user_id, fan_names: []]
+  self.permitted_attrs = [:phone_number, :notes, :status, :event_id, :total_seats, :user_id, :stop, fan_names: []]
 
   include DatatableController
 
   def datatable_columns
-    %i[event_id user_id total_seats status fan_names phone_number mail_sent notes]
+    %i[event_id user_id total_seats status fan_names phone_number mail_sent notes stop]
   end
 
   def model_scope
@@ -79,12 +79,13 @@ class ReservationsController < CrudController
 
   def create
     permitted = params.require(:reservation)
-                      .permit(:phone_number, :notes, :event_id, :user_id, :fans_count, fan_names: [])
+                      .permit(:phone_number, :notes, :stop, :event_id, :user_id, :fans_count, fan_names: [])
     @reservation = Reservation.new(
       event_id: permitted[:event_id],
       user_id: permitted[:user_id],
       notes: permitted[:notes],
       phone_number: permitted[:phone_number],
+      stop: permitted[:stop],
       fan_names: permitted[:fan_names].to_a.reject(&:blank?)
     )
     if @reservation.valid?

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -49,7 +49,7 @@ class ReservationsController < CrudController
 
   def form_create
     permitted = params.require(:reservation)
-                      .permit(:phone_number, :notes, :event_id,
+                      .permit(:phone_number, :notes, :event_id, :stop,
                               :user_id, :fans_count, fan_names: %i[first_name last_name])
     # params.require(:reservation)
     #       .permit(:phone_number, :notes, :event_id, fan_names: [])
@@ -64,7 +64,8 @@ class ReservationsController < CrudController
       user_id: current_user.id,
       notes: permitted[:notes],
       phone_number: permitted[:phone_number],
-      fan_names: fan_names
+      fan_names: fan_names,
+      stop: permitted[:stop]
     )
     @event = Event.find(permitted[:event_id])
     if @reservation.valid?

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -16,7 +16,8 @@ class EventDecorator < ApplicationDecorator
       object.available_seats,
       object.competition.to_s,
       object.venue,
-      object.poster_url
+      object.poster_url,
+      object.available_seats.join(', ')
     ]
   end
 end

--- a/app/decorators/event_decorator.rb
+++ b/app/decorators/event_decorator.rb
@@ -17,7 +17,7 @@ class EventDecorator < ApplicationDecorator
       object.competition.to_s,
       object.venue,
       object.poster_url,
-      object.available_seats.join(', ')
+      object.stops
     ]
   end
 end

--- a/app/decorators/reservation_decorator.rb
+++ b/app/decorators/reservation_decorator.rb
@@ -8,7 +8,8 @@ class ReservationDecorator < ApplicationDecorator
       object.user.to_s,
       object.fan_names,
       object.phone_number,
-      object.notes
+      object.notes,
+      object.stop
     ]
   end
 
@@ -21,7 +22,8 @@ class ReservationDecorator < ApplicationDecorator
       object.fan_names,
       object.phone_number,
       object.mail_sent,
-      object.notes
+      object.notes,
+      object.stop
     ]
   end
 end

--- a/app/models/concerns/reservation_csv.rb
+++ b/app/models/concerns/reservation_csv.rb
@@ -5,7 +5,7 @@ require 'csv'
 module ReservationCsv
   extend ActiveSupport::Concern
 
-  CSV_HEADERS = %w[email telefono cognome nome status ultimo_aggiornamento].freeze
+  CSV_HEADERS = %w[email telefono cognome nome status ultimo_aggiornamento fermata].freeze
   def csv_reservations
     lines = reservations
     CSV.generate do |csv|
@@ -23,9 +23,10 @@ module ReservationCsv
     phone_number = l.phone_number
     status = l.status
     last_update = l.updated_at
+    stop = l.stop
     l.fan_names.each do |n|
       last_name, first_name = n.split('|').map(&:strip)
-      csv << [email, phone_number, last_name, first_name, status, last_update]
+      csv << [email, phone_number, last_name, first_name, status, last_update, stop]
     end
   end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -71,6 +71,10 @@ class Event < ApplicationRecord
     100 * available_seats / total_seats
   end
 
+  def available_stops
+    @available_stops ||= stops&.split(',')&.map(&:strip)&.reject(&:empty?) || []
+  end
+
   private
 
   def set_slug_name!

--- a/app/schemas/reservation_schema.rb
+++ b/app/schemas/reservation_schema.rb
@@ -3,7 +3,7 @@
 module ReservationSchema
   module_function
 
-  def jsonschema(minimum: 1, maximum: 10, default: 1)
+  def jsonschema(minimum: 1, maximum: 10, default: 1, stops: [])
     {
       title: 'Prenota la trasferta',
       description: schema_description(maximum),
@@ -49,7 +49,16 @@ module ReservationSchema
         },
         notes: { type: 'string', title: 'Note' }
       }
-    }
+    }.tap do |h|
+      unless stops.empty?
+        h[:required] << 'stop'
+        h[:properties].merge!(stop: {
+                                type: 'string',
+                                title: 'Punto di partenza',
+                                enum: stops
+                              })
+      end
+    end
   end
 
   def ui_schema

--- a/app/views/crud/events/_form.html.haml
+++ b/app/views/crud/events/_form.html.haml
@@ -6,13 +6,13 @@
   %ul
     %li "Posti Totali": numero totale dei posti prenotabili. Se 0 o negativo, la trasferta è chiusa
     %li "Prenotabile da" e "Prenotabile a": giorni in cui la trasferta sarà prenotabile
-    %li "Audience": se everyone, tutti gli utenti attivi possono prenotare, altrimenti solo preferred e admin
+    %li "Audience": se everyone, tutti gli utenti attivi possono prenotare, altrimenti solo preferred/gold e admin
     %li "PAX": numero massimo di partecipanti per prenotazione
     %li "Url locandina": fondamentale, link alla locandina
     %li "Note": testo con informazioni utili (es. tdt, link acquisto biglietti etc)
     %li "Mezzo di trasporto": inserire bus, aereo oppure lasciare vuoto. Gli altri valori verrano filtrati e rimossi
     %li "Posti Disponibili": numero totale dei posti ancora disponibili. se 0 o negativo, la trasferta è chiusa
-    %li "Fermate": lista delle fermate (punti di partenza) separati da virgola es. Bergamo, Altro Luogo, Altro
+    %li "Fermate": lista delle fermate (punti di partenza) separati da virgola es. "Bergamo - Via Spino, Altro Luogo - Autostrada, Altro"
   %hr
 = crud_form(:competition_id, :date, :time, :venue, :home_team_id, :away_team_id, :season, :transport_mean, :total_seats, :bookable_from,
             :bookable_until, :audience, :pax, :poster_url, :notes, :confirmed_seats, :requested_seats, :rejected_seats, :available_seats, :score, :stops)

--- a/app/views/crud/events/_form.html.haml
+++ b/app/views/crud/events/_form.html.haml
@@ -12,7 +12,8 @@
     %li "Note": testo con informazioni utili (es. tdt, link acquisto biglietti etc)
     %li "Mezzo di trasporto": inserire bus, aereo oppure lasciare vuoto. Gli altri valori verrano filtrati e rimossi
     %li "Posti Disponibili": numero totale dei posti ancora disponibili. se 0 o negativo, la trasferta è chiusa
+    %li "Fermate": lista delle fermate (punti di partenza) separati da virgola es. Bergamo, Altro Luogo, Altro
   %hr
 = crud_form(:competition_id, :date, :time, :venue, :home_team_id, :away_team_id, :season, :transport_mean, :total_seats, :bookable_from,
-            :bookable_until, :audience, :pax, :poster_url, :notes, :confirmed_seats, :requested_seats, :rejected_seats, :available_seats, :score)
+            :bookable_until, :audience, :pax, :poster_url, :notes, :confirmed_seats, :requested_seats, :rejected_seats, :available_seats, :score, :stops)
 = render partial: 'shared/form_html5_support'

--- a/app/views/reservation_mailer/approved.html.haml
+++ b/app/views/reservation_mailer/approved.html.haml
@@ -17,6 +17,9 @@
     %li= n
 %p= t('reservations.show.phone_number', number: @reservation.phone_number)
 
+- if @reservation.stop.present?
+  %p Punto di partenza: #{@reservation.stop}
+
 - if @event.poster_url
   %hr
   %a{ href: @event.poster_url, target: '_blank', rel: 'noopener noreferrer' }

--- a/app/views/reservation_mailer/received.html.haml
+++ b/app/views/reservation_mailer/received.html.haml
@@ -13,6 +13,9 @@
     %li= n
 %p= t('reservations.show.phone_number', number: @reservation.phone_number)
 
+- if @reservation.stop.present?
+  %p Punto di partenza: #{@reservation.stop}
+
 - if @event.poster_url
   %hr
   %a{ href: @event.poster_url, target: '_blank', rel: 'noopener noreferrer' }

--- a/app/views/reservations/edit.html.haml
+++ b/app/views/reservations/edit.html.haml
@@ -39,6 +39,7 @@
               = f.input :fan_first_name, as: :fake, label: false, placeholder: 'Nome', input_html: { value: current_user.first_name }
               %button.btn.btn-primary#add-guest{ type: :button } Aggiungi Partecipante
             = f.input :phone_number
+            = f.input :stop
             = f.input :event_id, collection: Event.include_all.order(:date).bookable, include_blank: false
             = f.input :user_id, collection: User.order(:email), include_blank: false
             = f.input :notes

--- a/app/views/reservations/new.html.haml
+++ b/app/views/reservations/new.html.haml
@@ -39,6 +39,7 @@
               = f.input :fan_first_name, as: :fake, label: false, placeholder: 'Nome', input_html: { value: current_user.first_name }
               %button.btn.btn-primary#add-guest{ type: :button } Aggiungi Partecipante
             = f.input :phone_number
+            = f.input :stop
             = f.input :event_id, collection: Event.include_all.order(:date).bookable.upcoming, include_blank: false
             = f.input :user_id, collection: User.order(:email).all, include_blank: false
             = f.input :notes

--- a/app/views/reservations/status.html.haml
+++ b/app/views/reservations/status.html.haml
@@ -5,6 +5,9 @@
     - @reservation.fan_names.each do |n|
       %li= n
   %p= t('reservations.show.phone_number', number: @reservation.phone_number)
+  - if @reservation.stop.present?
+    %p Punto di partenza: #{@reservation.stop}
+
 - if @reservation.pending?
   .row
     %p Riceverai aggiornamenti sulla tua mail.

--- a/config/locales/models/event.en.yml
+++ b/config/locales/models/event.en.yml
@@ -29,3 +29,4 @@ en:
         transport_mean: Transport Mean
         available_seats: Available Seats
         total_seats: Total Seats
+        stops: Stops

--- a/config/locales/models/event.it.yml
+++ b/config/locales/models/event.it.yml
@@ -29,3 +29,4 @@ it:
         transport_mean: Mezzo di trasporto
         available_seats: Posti Disponibili
         total_seats: Posti Totali
+        stops: Fermate

--- a/config/locales/models/reservation.en.yml
+++ b/config/locales/models/reservation.en.yml
@@ -17,3 +17,4 @@ en:
         email: Email
         event_id: Event
         mail_sent: Mail Sent
+        stop: Stop

--- a/config/locales/models/reservation.it.yml
+++ b/config/locales/models/reservation.it.yml
@@ -17,3 +17,4 @@ it:
         email: Email
         event_id: Partita
         mail_sent: Mail Inviata
+        stop: Fermata

--- a/db/migrate/20190807201231_add_stops_to_events.rb
+++ b/db/migrate/20190807201231_add_stops_to_events.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddStopsToEvents < ActiveRecord::Migration[5.2]
+  def up
+    add_column :events, :stops, :string
+  end
+
+  def down
+    remove_column :events, :stops
+  end
+end

--- a/db/migrate/20190808145009_add_stop_to_reservation.rb
+++ b/db/migrate/20190808145009_add_stop_to_reservation.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddStopToReservation < ActiveRecord::Migration[5.2]
+  def up
+    add_column :reservations, :stop, :string
+  end
+
+  def down
+    remove_column :reservations, :stop
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,144 +10,146 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_171_218_103_411) do
+ActiveRecord::Schema.define(version: 2019_08_07_201231) do
+
   # These are extensions that must be enabled in order to support this database
-  enable_extension 'plpgsql'
+  enable_extension "plpgsql"
 
-  create_table 'albums', id: :serial, force: :cascade do |t|
-    t.string 'title'
-    t.string 'url'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'event_id'
-    t.index ['event_id'], name: 'index_albums_on_event_id'
+  create_table "albums", id: :serial, force: :cascade do |t|
+    t.string "title"
+    t.string "url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "event_id"
+    t.index ["event_id"], name: "index_albums_on_event_id"
   end
 
-  create_table 'competitions', id: :serial, force: :cascade do |t|
-    t.string 'name'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'slug'
+  create_table "competitions", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "slug"
   end
 
-  create_table 'events', id: :serial, force: :cascade do |t|
-    t.date 'date'
-    t.time 'time'
-    t.string 'season'
-    t.string 'score'
-    t.text 'notes'
-    t.integer 'home_team_id'
-    t.integer 'away_team_id'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'competition_id'
-    t.string 'venue'
-    t.string 'poster_url'
-    t.date 'bookable_from'
-    t.date 'bookable_until'
-    t.integer 'requested_seats', default: 0
-    t.integer 'confirmed_seats', default: 0
-    t.string 'custom_name'
-    t.string 'slug'
-    t.string 'audience', default: 'everyone'
-    t.integer 'pax', default: 10
-    t.integer 'rejected_seats', default: 0
-    t.string 'transport_mean'
-    t.integer 'available_seats', default: 0
-    t.integer 'total_seats', default: 0
-    t.index ['away_team_id'], name: 'index_events_on_away_team_id'
-    t.index ['competition_id'], name: 'index_events_on_competition_id'
-    t.index ['home_team_id'], name: 'index_events_on_home_team_id'
+  create_table "events", id: :serial, force: :cascade do |t|
+    t.date "date"
+    t.time "time"
+    t.string "season"
+    t.string "score"
+    t.text "notes"
+    t.integer "home_team_id"
+    t.integer "away_team_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "competition_id"
+    t.string "venue"
+    t.string "poster_url"
+    t.date "bookable_from"
+    t.date "bookable_until"
+    t.integer "requested_seats", default: 0
+    t.integer "confirmed_seats", default: 0
+    t.string "custom_name"
+    t.string "slug"
+    t.string "audience", default: "everyone"
+    t.integer "pax", default: 10
+    t.integer "rejected_seats", default: 0
+    t.string "transport_mean"
+    t.integer "available_seats", default: 0
+    t.integer "total_seats", default: 0
+    t.string "stops"
+    t.index ["away_team_id"], name: "index_events_on_away_team_id"
+    t.index ["competition_id"], name: "index_events_on_competition_id"
+    t.index ["home_team_id"], name: "index_events_on_home_team_id"
   end
 
-  create_table 'friendly_id_slugs', id: :serial, force: :cascade do |t|
-    t.string 'slug', null: false
-    t.integer 'sluggable_id', null: false
-    t.string 'sluggable_type', limit: 50
-    t.string 'scope'
-    t.datetime 'created_at'
-    t.index %w[slug sluggable_type scope], name: 'index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope', unique: true
-    t.index %w[slug sluggable_type], name: 'index_friendly_id_slugs_on_slug_and_sluggable_type'
-    t.index ['sluggable_id'], name: 'index_friendly_id_slugs_on_sluggable_id'
-    t.index ['sluggable_type'], name: 'index_friendly_id_slugs_on_sluggable_type'
+  create_table "friendly_id_slugs", id: :serial, force: :cascade do |t|
+    t.string "slug", null: false
+    t.integer "sluggable_id", null: false
+    t.string "sluggable_type", limit: 50
+    t.string "scope"
+    t.datetime "created_at"
+    t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
+    t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
+    t.index ["sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_id"
+    t.index ["sluggable_type"], name: "index_friendly_id_slugs_on_sluggable_type"
   end
 
-  create_table 'posts', id: :serial, force: :cascade do |t|
-    t.string 'title', null: false
-    t.string 'image_url'
-    t.text 'content'
-    t.date 'date'
-    t.string 'slug'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "posts", id: :serial, force: :cascade do |t|
+    t.string "title", null: false
+    t.string "image_url"
+    t.text "content"
+    t.date "date"
+    t.string "slug"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'reservations', id: :serial, force: :cascade do |t|
-    t.integer 'total_seats'
-    t.string 'fan_names', default: [], array: true
-    t.text 'notes'
-    t.string 'status'
-    t.string 'phone_number'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.integer 'user_id'
-    t.integer 'event_id'
-    t.date 'mail_sent'
-    t.index ['event_id'], name: 'index_reservations_on_event_id'
-    t.index ['user_id'], name: 'index_reservations_on_user_id'
+  create_table "reservations", id: :serial, force: :cascade do |t|
+    t.integer "total_seats"
+    t.string "fan_names", default: [], array: true
+    t.text "notes"
+    t.string "status"
+    t.string "phone_number"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "user_id"
+    t.integer "event_id"
+    t.date "mail_sent"
+    t.index ["event_id"], name: "index_reservations_on_event_id"
+    t.index ["user_id"], name: "index_reservations_on_user_id"
   end
 
-  create_table 'teams', id: :serial, force: :cascade do |t|
-    t.string 'name'
-    t.string 'country'
-    t.string 'url'
-    t.string 'image_url'
-    t.text 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "teams", id: :serial, force: :cascade do |t|
+    t.string "name"
+    t.string "country"
+    t.string "url"
+    t.string "image_url"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'transport_means', id: :serial, force: :cascade do |t|
-    t.string 'kind'
-    t.string 'company'
-    t.string 'phone_number'
-    t.string 'email'
-    t.text 'description'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
+  create_table "transport_means", id: :serial, force: :cascade do |t|
+    t.string "kind"
+    t.string "company"
+    t.string "phone_number"
+    t.string "email"
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
-  create_table 'users', id: :serial, force: :cascade do |t|
-    t.string 'email', default: '', null: false
-    t.string 'encrypted_password', default: '', null: false
-    t.string 'reset_password_token'
-    t.datetime 'reset_password_sent_at'
-    t.datetime 'remember_created_at'
-    t.integer 'sign_in_count', default: 0, null: false
-    t.datetime 'current_sign_in_at'
-    t.datetime 'last_sign_in_at'
-    t.inet 'current_sign_in_ip'
-    t.inet 'last_sign_in_ip'
-    t.string 'role', default: 'fan'
-    t.string 'status', default: 'pending'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'first_name'
-    t.string 'last_name'
-    t.date 'date_of_birth'
-    t.string 'place_of_birth'
-    t.string 'phone_number'
-    t.boolean 'newsletter', default: true
-    t.date 'activation_date'
-    t.boolean 'mailing_listed', default: false
-    t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token', unique: true
+  create_table "users", id: :serial, force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
+    t.datetime "reset_password_sent_at"
+    t.datetime "remember_created_at"
+    t.integer "sign_in_count", default: 0, null: false
+    t.datetime "current_sign_in_at"
+    t.datetime "last_sign_in_at"
+    t.inet "current_sign_in_ip"
+    t.inet "last_sign_in_ip"
+    t.string "role", default: "fan"
+    t.string "status", default: "pending"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.date "date_of_birth"
+    t.string "place_of_birth"
+    t.string "phone_number"
+    t.boolean "newsletter", default: true
+    t.date "activation_date"
+    t.boolean "mailing_listed", default: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key 'albums', 'events'
-  add_foreign_key 'events', 'competitions'
-  add_foreign_key 'events', 'teams', column: 'away_team_id'
-  add_foreign_key 'events', 'teams', column: 'home_team_id'
-  add_foreign_key 'reservations', 'events'
-  add_foreign_key 'reservations', 'users'
+  add_foreign_key "albums", "events"
+  add_foreign_key "events", "competitions"
+  add_foreign_key "events", "teams", column: "away_team_id"
+  add_foreign_key "events", "teams", column: "home_team_id"
+  add_foreign_key "reservations", "events"
+  add_foreign_key "reservations", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_08_07_201231) do
+ActiveRecord::Schema.define(version: 2019_08_08_145009) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -95,6 +95,7 @@ ActiveRecord::Schema.define(version: 2019_08_07_201231) do
     t.integer "user_id"
     t.integer "event_id"
     t.date "mail_sent"
+    t.string "stop"
     t.index ["event_id"], name: "index_reservations_on_event_id"
     t.index ["user_id"], name: "index_reservations_on_user_id"
   end

--- a/spec/factories/event.rb
+++ b/spec/factories/event.rb
@@ -15,6 +15,7 @@ FactoryGirl.define do
     requested_seats { 20 }
     confirmed_seats { 5 }
     audience { 'everyone' }
+    stops { nil }
 
     competition
   end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -41,6 +41,8 @@ RSpec.describe Event, type: :model do
     it { should respond_to(:pax) }
     it { should respond_to(:audience) }
     it { should respond_to(:transport_mean) }
+    it { should respond_to(:stops) }
+    it { should respond_to(:available_stops) }
 
     it 'belongs to a competition' do
       expect(subject.competition).to eq(competition)
@@ -219,6 +221,62 @@ RSpec.describe Event, type: :model do
 
     it 'should assign the custom_name as slug_name' do
       expect(subject.slug).to eq(subject.custom_name)
+    end
+  end
+
+  context '.available_stops' do
+    let(:event) { FactoryGirl.build(:event) }
+
+    it 'handles null stops' do
+      aggregate_failures do
+        expect(event.stops).to be_nil
+        expect(event.available_stops).to match_array([])
+      end
+    end
+
+    it 'handles empty stops' do
+      event.stops = ''
+
+      aggregate_failures do
+        expect(event.stops).to eq('')
+        expect(event.available_stops).to match_array([])
+      end
+    end
+
+    it 'handles empty spaced stops' do
+      event.stops = '  '
+
+      aggregate_failures do
+        expect(event.stops).to eq('  ')
+        expect(event.available_stops).to match_array([])
+      end
+    end
+
+    it 'handles single-valued stops' do
+      event.stops = 'Bergamo'
+
+      aggregate_failures do
+        expect(event.stops).to eq('Bergamo')
+        expect(event.available_stops).to match_array(%w[Bergamo])
+      end
+    end
+
+    it 'handles value + space stops' do
+      event.stops = ' Bergamo,  '
+
+      aggregate_failures do
+        expect(event.stops).to eq(' Bergamo,  ')
+        expect(event.available_stops).to match_array(%w[Bergamo])
+      end
+    end
+
+    it 'handles multi-value stops' do
+      event.stops = ' Bergamo, Altro '
+
+      aggregate_failures do
+        expect(event.stops).to eq(' Bergamo, Altro ')
+        expect(event.available_stops).to match_array(%w[Bergamo Altro])
+      end
     end
   end
 end

--- a/spec/schemas/reservation_schema_spec.rb
+++ b/spec/schemas/reservation_schema_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ReservationSchema do
+  describe '.jsonschema' do
+    context 'when stops are not provided' do
+      it 'returns some default values discarding stops' do
+        j = ReservationSchema.jsonschema(stops: [])
+
+        aggregate_failures do
+          expect(j.keys).to match_array(%i[title description type required properties])
+          expect(j[:required]).to match_array(%w[phone_number fan_names])
+          expect(j[:properties].keys).to match_array(
+            %i[
+              authenticity_token event_id user_id phone_number
+              fans_count fan_names notes
+            ]
+          )
+        end
+      end
+    end
+
+    context 'when stops are provided' do
+      it 'returns some default values adding stops' do
+        j = ReservationSchema.jsonschema(stops: %w[Bergamo Foo Bar])
+
+        aggregate_failures do
+          expect(j.keys).to match_array(%i[title description type required properties])
+          expect(j[:required]).to match_array(%w[phone_number fan_names stop])
+          expect(j[:properties].keys).to match_array(
+            %i[
+              authenticity_token event_id user_id phone_number
+              fans_count fan_names notes stop
+            ]
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Relates to #7

Implementation:

* [x] Add stops string column to events table
* [x] Introduce events#stops as a comma separated list of locations
* [x] Add stops to events CRUD
* [x] Add stops string column to reservations table
* [x] Add stops to reservations CRUD and export files
* [x] Add stops to reservations form when specified in the event

Release plan:

* Build docker image
* Release on cheidelacoriera staging environment
* Validate the specifications with @alebrigno 