### PR TITLE
Restrict availability visibility

### DIFF
--- a/app/javascript/components/event/availability_progressbar.jsx
+++ b/app/javascript/components/event/availability_progressbar.jsx
@@ -20,7 +20,7 @@ class EventAvailabilityProgressbar extends Component {
     }
 
     _getVisibleBar = (game) => {
-        if (game.currentUser.canBook) {
+        if (game.currentUser.canSeeAvailabilty) {
             let divStyle = {
                 width: this.state.occupancy + '%'
             }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,4 +74,8 @@ class User < ApplicationRecord
 
     true
   end
+
+  def can_see_availability?
+    active? && ROLES.index(role).to_i.positive?
+  end
 end

--- a/app/views/api/v1/events/list.json.jbuilder
+++ b/app/views/api/v1/events/list.json.jbuilder
@@ -49,6 +49,7 @@ json.array! @events.each do |event|
   json.currentUser do
     json.role current_user&.role
     json.canBook current_user&.can_book?(event)
+    json.canSeeAvailabilty current_user&.can_see_availability? || false
     json.booked current_user && event.booked_by?(current_user.id)
   end
   json.date I18n.l(event.date, format: :long)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -17,6 +17,8 @@ RSpec.describe User, type: :model do
     it { should respond_to(:phone_number) }
     it { should respond_to(:newsletter) }
     it { should respond_to(:activation_date) }
+    it { should respond_to(:can_book?) }
+    it { should respond_to(:can_see_availability?) }
 
     it 'has default role' do
       expect(subject.role).to eq('fan')
@@ -91,6 +93,7 @@ RSpec.describe User, type: :model do
         expect(fan_user.can_book?(preferred_event)).to be(false)
         expect(fan_user.can_book?(gold_event)).to be(false)
         expect(fan_user.can_book?(expired_event)).to be(false)
+        expect(fan_user.can_see_availability?).to be(false)
       end
     end
 
@@ -100,6 +103,7 @@ RSpec.describe User, type: :model do
         expect(preferred_user.can_book?(preferred_event)).to be(true)
         expect(preferred_user.can_book?(gold_event)).to be(false)
         expect(preferred_user.can_book?(expired_event)).to be(false)
+        expect(preferred_user.can_see_availability?).to be(true)
       end
     end
 
@@ -109,6 +113,7 @@ RSpec.describe User, type: :model do
         expect(gold_user.can_book?(preferred_event)).to be(true)
         expect(gold_user.can_book?(gold_event)).to be(true)
         expect(gold_user.can_book?(expired_event)).to be(false)
+        expect(gold_user.can_see_availability?).to be(true)
       end
     end
 
@@ -117,7 +122,8 @@ RSpec.describe User, type: :model do
         expect(admin_user.can_book?(public_event)).to be(true)
         expect(admin_user.can_book?(preferred_event)).to be(true)
         expect(admin_user.can_book?(gold_event)).to be(true)
-        expect(gold_user.can_book?(expired_event)).to be(false)
+        expect(admin_user.can_book?(expired_event)).to be(false)
+        expect(admin_user.can_see_availability?).to be(true)
       end
     end
   end


### PR DESCRIPTION
Do not let anyone see how much availability there is for an event.
Restrict the visibility to preferred users only