### PR TITLE
fix: model scope missing some attributes for reservations find entry

### DIFF
--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -106,4 +106,9 @@ class ReservationsController < CrudController
     Event.find(event_id).recalculate_seats!
     redirect_to reservations_event_url(slug)
   end
+
+  # Sets an existing model entry from the given id.
+  def find_entry
+    Reservation.includes(:user, :event).find(params[:id])
+  end
 end

--- a/spec/requests/reservations_show_spec.rb
+++ b/spec/requests/reservations_show_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'ReservationsController#show', type: :request do
+  let(:competition1) { FactoryGirl.create(:competition) }
+  let(:team_a) { FactoryGirl.create(:team) }
+  let(:team_b) { FactoryGirl.create(:team) }
+  let(:fan) { FactoryGirl.create(:user, role: :fan, status: :active) }
+  let(:admin) { FactoryGirl.create(:user, role: :admin, status: :active) }
+  let(:eventa) do
+    FactoryGirl.create(
+      :event, requested_seats: 0, confirmed_seats: 0,
+              competition: competition1, home_team: team_a, away_team: team_b
+    )
+  end
+  let!(:reservation1) do
+    FactoryGirl.create(:reservation, user: fan, event: eventa, fan_names: %w[Foo|Bar])
+  end
+
+  before(:each) do
+    Rails.cache.clear
+  end
+
+  it 'prevents 500s' do
+    sign_in admin
+
+    get "/reservations/#{reservation1.id}"
+
+    expect(status).to eq(200)
+  end
+end


### PR DESCRIPTION
```
30 Dec 2019 23:59:55.840248 <190>1 2019-12-30T22:59:55.343966+00:00 app web.1 - - I, [2019-12-30T22:59:55.343895 #468] INFO -- : [c1fdf366-a199-409e-8cb4-599a47293cb2] Completed 500 Internal Server Error in 147ms (ActiveRecord: 29.9ms)
30 Dec 2019 23:59:55.840183 <190>1 2019-12-30T22:59:55.345067+00:00 app web.1 - - F, [2019-12-30T22:59:55.344986 #468] FATAL -- : [c1fdf366-a199-409e-8cb4-599a47293cb2]
30 Dec 2019 23:59:55.840241 <190>1 2019-12-30T22:59:55.345113+00:00 app web.1 - - F, [2019-12-30T22:59:55.345058 #468] FATAL -- : [c1fdf366-a199-409e-8cb4-599a47293cb2] ActionView::Template::Error (missing attribute: created_at):
30 Dec 2019 23:59:55.840229 <190>1 2019-12-30T22:59:55.345261+00:00 app web.1 - - F, [2019-12-30T22:59:55.345201 #468] FATAL -- : [c1fdf366-a199-409e-8cb4-599a47293cb2] 1: = render_attrs entry, *default_crud_attrs
30 Dec 2019 23:59:55.840183 <190>1 2019-12-30T22:59:55.345303+00:00 app web.1 - - F, [2019-12-30T22:59:55.345251 #468] FATAL -- : [c1fdf366-a199-409e-8cb4-599a47293cb2]
30 Dec 2019 23:59:55.840230 <190>1 2019-12-30T22:59:55.345362+00:00 app web.1 - - F, [2019-12-30T22:59:55.345310 #468] FATAL -- : [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/format_helper.rb:115:in `format_type'
30 Dec 2019 23:59:55.906181 <190>1 2019-12-30T22:59:55.345363+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/format_helper.rb:36:in `format_attr'
30 Dec 2019 23:59:55.906182 <190>1 2019-12-30T22:59:55.345364+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/format_helper.rb:58:in `labeled_attr'
30 Dec 2019 23:59:55.906191 <190>1 2019-12-30T22:59:55.345365+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/format_helper.rb:52:in `block in render_attrs'
30 Dec 2019 23:59:55.906174 <190>1 2019-12-30T22:59:55.345367+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/utility_helper.rb:20:in `map'
30 Dec 2019 23:59:55.906180 <190>1 2019-12-30T22:59:55.345368+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/utility_helper.rb:20:in `safe_join'
30 Dec 2019 23:59:55.906189 <190>1 2019-12-30T22:59:55.345369+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/utility_helper.rb:14:in `content_tag_nested'
30 Dec 2019 23:59:55.906182 <190>1 2019-12-30T22:59:55.345370+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/helpers/format_helper.rb:51:in `render_attrs'
30 Dec 2019 23:59:55.906240 <190>1 2019-12-30T22:59:55.345371+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/views/crud/_attrs.html.haml:1:in `_app_views_crud__attrs_html_haml__4070035534012743301_47301636903940'
30 Dec 2019 23:59:55.906253 <190>1 2019-12-30T22:59:55.345373+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/views/reservations/show.html.haml:8:in `_app_views_reservations_show_html_haml___1510006994449314169_47301635630080'
30 Dec 2019 23:59:55.906192 <190>1 2019-12-30T22:59:55.345374+00:00 app web.1 - - [c1fdf366-a199-409e-8cb4-599a47293cb2] app/controllers/dry_crud/render_callbacks.rb:23:in `render'
31 Dec 2019 00:00:00.344323 <158>1 2019-12-30T22:59:55.350961+00:00 heroku router - - at=info method=GET path="/reservations/4731?locale=it" host=www.cheidelacoriera.com request_id=c1fdf366-a199-409e-8cb4-599a47293cb2 fwd="176.200.83.30" dyno=web.1 connect=0ms service=157ms status=500 bytes=1994 protocol=https
```