### PR TITLE
fix: @rails/ujs deleted by yarn autoclean

### DIFF
--- a/.yarnclean
+++ b/.yarnclean
@@ -8,8 +8,8 @@ powered-test
 docs
 doc
 website
-images
-assets
+# images
+# assets
 
 # examples
 example

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,7 +7,7 @@
 // To reference this file, add <%= javascript_pack_tag 'application' %> to the appropriate
 // layout file, like app/views/layouts/application.html.erb
 
-// require("@rails/ujs").start();
+require("@rails/ujs").start();
 // require("turbolinks").start()
 // require("@rails/activestorage").start()
 // require("channels")
@@ -16,3 +16,7 @@
 var componentRequireContext = require.context("components", true);
 var ReactRailsUJS = require("react_ujs");
 ReactRailsUJS.useContext(componentRequireContext);
+
+// https://stackoverflow.com/questions/56128114
+// import Rails from '@rails/ujs';
+// Rails.start();

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "whatwg-fetch": "^3.4.1",
     "wowjs": "^1.1.3"
   },
-  "version": "0.1.0",
   "devDependencies": {
     "webpack-dev-server": "^3.11.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1903,9 +1903,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001131:
-  version "1.0.30001132"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001132.tgz#309279274f10d3aa736aa91fa269fcc8d0cd7ef9"
-  integrity sha512-zk5FXbnsmHa0Ktc/NOZJRr+ilXva+2KFJuRiQfnjkxJfV/7DYP5C27lSQF++/veCUzVWE5xecZnSBJjf6fSwJA==
+  version "1.0.30001133"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001133.tgz#ec564c5495311299eb05245e252d589a84acd95e"
+  integrity sha512-s3XAUFaC/ntDb1O3lcw9K8MPeOW7KO3z9+GzAoBxfz1B0VdacXPMKgFUtG4KIsgmnbexmi013s9miVu4h+qMHw==
 
 case-sensitive-paths-webpack-plugin@^2.2.0:
   version "2.3.0"


### PR DESCRIPTION
* **Description**: Rails does not behave as expected. When clicking on delete, it redirects to get.
* **Reason**: while migrating from jquery-ujs to rails-ujs, the new ujs library was not included duw to a webpack compile error. THe error was due to yarnautoclean suppressing the directory with the library files