### PR TITLE
fix: resolve warnings raised by wow.js

### DIFF
--- a/app/assets/javascripts/topnav.js.erb
+++ b/app/assets/javascripts/topnav.js.erb
@@ -11,7 +11,7 @@ $().ready(function (){
     $('.dropdown-toggle').dropdown();
 
     /* Wow */
-    new WOW().init();
+    new WOW({live: false}).init();
 
     /* Placeholders */
     // $('input[type="text"], input[type="password"], textarea').each(function(){


### PR DESCRIPTION
In the browser console, wow is raising this warnings:
```
wow.min.js:69 MutationObserver is not supported by your browser.
t @ wow.min.js:69
wow.min.js:69 WOW.js cannot detect dom mutations, please call .sync() after loading new content.
```

this solution is based on https://stackoverflow.com/questions/58354694/wow-js-mutationobserver-is-not-supported-by-your-browser