### PR TITLE
chore: unpin dev gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,11 +57,11 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'listen', '~> 3.2.0'
-  gem 'web-console', '>= 3.3.0'
+  gem 'listen'
+  gem 'web-console'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
-  gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'spring-watcher-listen'
 end
 
 group :lint do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,7 +170,7 @@ GEM
     json (2.5.1)
     kgio (2.11.4)
     libv8-node (15.14.0.1)
-    listen (3.2.1)
+    listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     lograge (0.11.2)
@@ -394,7 +394,7 @@ DEPENDENCIES
   haml-lint
   haml-rails
   jbuilder
-  listen (~> 3.2.0)
+  listen
   lograge
   mini_racer
   overcommit
@@ -416,13 +416,13 @@ DEPENDENCIES
   simple_form
   simplecov (~> 0.17.0)
   spring
-  spring-watcher-listen (~> 2.0.0)
+  spring-watcher-listen
   sprockets
   tzinfo-data
   uglifier
   unicorn
   unicorn-worker-killer
-  web-console (>= 3.3.0)
+  web-console
   webpacker (= 4.2.2)
 
 RUBY VERSION


### PR DESCRIPTION
This CR consist in stop forcing a version for some development utilities such as console, listen and spring. These gems have no impact on production code.