### PR TITLE
ci: restore travis ci tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ branches:
   only:
   - master
 
-addons:
-  postgresql: '9.6' # same as production
+# https://docs.travis-ci.com/user/database-setup/#postgresql
+services:
+  - postgresql
+# addons:
+#  postgresql: '9.6' # same as production
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ jobs:
         - bundle exec rake db:test:prepare
         - bundle exec rspec spec
       before_install:
-        - ruby --version
-        - rvm install $(cat .ruby-version)
+        - ruby --version
+        - rvm install $(cat .ruby-version)
         - ruby --version
         - gem install bundler -v "$(tail -n 1 Gemfile.lock | tr -d '[:blank:]')"
         - bundle install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ arch: arm64 # this should grant free buildshttps://travis-ci.community/t/free-os
 language: node_js
 node_js:
   - "10.18.0"
+branches:
+  only:
+  - master
 
 addons:
   postgresql: '9.6' # same as production

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 dist: xenial
+arch: arm64 # this should grant free buildshttps://travis-ci.community/t/free-oss-credits-usage-calculation/10832/4
 language: node_js
 node_js:
   - "10.18.0"


### PR DESCRIPTION
The purpose of this PR is to keep track of the migration steps execution : https://docs.travis-ci.com/user/migrate/open-source-repository-migration and to trigger a new build.

https://travis-ci.com/github/mberlanda/cheidelacoriera/builds/233931412

I may also consider to move to a different arch for testing to use free-tier in travis-ci: https://docs.travis-ci.com/user/billing-overview/#partner-queue-solution