### PR TITLE
chore: upgrade to bullseye and ruby 2.7.8

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.7.0
+          ruby-version: 2.7.8
       - name: Bundle audit
         run: |
           bundle exec bundle-audit --update
@@ -53,7 +53,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           bundler-cache: true
-          ruby-version: 2.7.0
+          ruby-version: 2.7.8
       - name: Setup Node
         uses: actions/setup-node@v1
         with:

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -2,7 +2,7 @@
 # STEP 1 build base image
 ############################
 
-FROM ruby:2.7.0-buster as base
+FROM ruby:2.7.8-bullseye as base
 
 RUN apt-get update \
     && apt-get install -y apt-transport-https \
@@ -22,7 +22,10 @@ WORKDIR "${WORKDIR}"
 COPY .ruby-version Gemfile Gemfile.lock "${WORKDIR}/"
 
 RUN gem install bundler -v "$(tail -n 1 Gemfile.lock | tr -d '[:blank:]')"
-RUN bundle install --no-cache --jobs 4 --deployment --without development test lint || bundle check
+RUN bundle config set deployment 'true' && \
+    bundle config set no-cache 'true' && \
+    bundle config set without 'development test lint' && \
+    bundle install --jobs 4 || bundle check
 
 COPY Rakefile config.ru "${WORKDIR}/"
 
@@ -44,12 +47,14 @@ FROM base as assets
 ENV NODE_ENV "production"
 
 # Install node and yarn
-RUN curl --silent --show-error --location \
-      https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-    && echo "deb https://deb.nodesource.com/node_16.x/ stretch main" > /etc/apt/sources.list.d/nodesource.list \
-    && curl --silent --show-error --location https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ADD https://deb.nodesource.com/gpgkey/nodesource.gpg.key /tmp/node-pubkey.gpgkey
+RUN apt-key add /tmp/node-pubkey.gpgkey && rm /tmp/node-pubkey.gpgkey
+ADD https://dl.yarnpkg.com/debian/pubkey.gpg /tmp/yarn-pubkey.gpg
+RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
+RUN echo "deb https://deb.nodesource.com/node_16.x/ stretch main" > /etc/apt/sources.list.d/nodesource.list \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     # Need to update debian version
+    && rm /etc/apt/sources.list.d/nodesource.* \
     && apt-get update --allow-releaseinfo-change\
     && apt-get install -y --no-install-recommends \
        nodejs yarn

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -2,7 +2,7 @@
 # STEP 1 build base image
 ############################
 
-FROM ruby:2.7.0-buster as base
+FROM ruby:2.7.8-bullseye as base
 
 RUN apt-get update \
     && apt-get install -y apt-transport-https \
@@ -22,7 +22,7 @@ WORKDIR "${WORKDIR}"
 COPY .ruby-version Gemfile Gemfile.lock "${WORKDIR}/"
 
 RUN gem install bundler -v "$(tail -n 1 Gemfile.lock | tr -d '[:blank:]')"
-RUN bundle config set deployment 'true' && \ 
+RUN bundle config set deployment 'true' && \
     bundle config set no-cache 'true' && \
     bundle config set without 'development test lint' && \
     bundle install --jobs 4 || bundle check
@@ -47,12 +47,14 @@ FROM base as assets
 ENV NODE_ENV "production"
 
 # Install node and yarn
-RUN curl --silent --show-error --location \
-      https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - \
-    && echo "deb https://deb.nodesource.com/node_16.x/ stretch main" > /etc/apt/sources.list.d/nodesource.list \
-    && curl --silent --show-error --location https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+ADD https://deb.nodesource.com/gpgkey/nodesource.gpg.key /tmp/node-pubkey.gpgkey
+RUN apt-key add /tmp/node-pubkey.gpgkey && rm /tmp/node-pubkey.gpgkey
+ADD https://dl.yarnpkg.com/debian/pubkey.gpg /tmp/yarn-pubkey.gpg
+RUN apt-key add /tmp/yarn-pubkey.gpg && rm /tmp/yarn-pubkey.gpg
+RUN echo "deb https://deb.nodesource.com/node_16.x/ stretch main" > /etc/apt/sources.list.d/nodesource.list \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" > /etc/apt/sources.list.d/yarn.list \
     # Need to update debian version
+    && rm /etc/apt/sources.list.d/nodesource.* \
     && apt-get update --allow-releaseinfo-change\
     && apt-get install -y --no-install-recommends \
        nodejs yarn

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ end
 
 gem 'haml-rails'
 gem 'jbuilder' # TODO: remove the couple of templates using it
-gem 'mini_racer'
+gem 'mini_racer', '0.6.0'
 gem 'pg'
 gem 'rails', '< 7' # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'react-rails', '~> 2.4'
@@ -79,4 +79,4 @@ end
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 # gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
-ruby '2.7.0'
+ruby '2.7.8'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,7 +159,7 @@ GEM
     js_cookie_rails (2.2.0)
       railties (>= 3.1)
     kgio (2.11.4)
-    libv8-node (15.14.0.1)
+    libv8-node (16.10.0.0)
     listen (3.6.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -177,8 +177,8 @@ GEM
     method_source (1.0.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
-    mini_racer (0.4.0)
-      libv8-node (~> 15.14.0.0)
+    mini_racer (0.6.0)
+      libv8-node (~> 16.10.0.0)
     minitest (5.16.3)
     multi_json (1.15.0)
     nio4r (2.5.8)
@@ -387,7 +387,7 @@ DEPENDENCIES
   jbuilder
   listen
   lograge
-  mini_racer
+  mini_racer (= 0.6.0)
   overcommit
   pg
   rails (< 7)
@@ -417,7 +417,7 @@ DEPENDENCIES
   webpacker (< 7)
 
 RUBY VERSION
-   ruby 2.7.0p0
+   ruby 2.7.8p0
 
 BUNDLED WITH
    2.3.8

--- a/stack/docker/entrypoint-worker.sh
+++ b/stack/docker/entrypoint-worker.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 IFS=$'\n\t'
 
 # PORT=${PORT:-3001}
-export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so
 
 if [[ "${RAILS_DB_MIGRATE}" == "true" ]]; then
   bundle exec rake db:migrate

--- a/stack/docker/entrypoint.sh
+++ b/stack/docker/entrypoint.sh
@@ -4,7 +4,7 @@ IFS=$'\n\t'
 
 PORT=${PORT:-3001}
 RAILS_DB_SEED=${RAILS_DB_SEED:-false}
-export LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so
+export LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libjemalloc.so
 
 if [[ "${RAILS_DB_MIGRATE}" == "true" ]]; then
   bundle exec rake db:migrate


### PR DESCRIPTION
### Revision 1

* Upgrade from `buster` to `bullseye` - Buster reached EOL on 2022-09-10 https://wiki.debian.org/DebianReleases#Production_Releases
* Upgrade to the latest ruby <3 available version in `bullseye`
* Update CI/CD scripts to ruby 2.7.8
* `mini-racer` to a version distributing required dependencies for libv8 and python-compact
* Address warnings due to reading STDOUT to add gpg keys for node and yarn
* Update LD_PRELOAD path due to the arch change in the distro of base image: `ERROR: ld.so: object '/usr/lib/x86_64-linux-gnu/libjemalloc.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.`
